### PR TITLE
consistently add missing libjpeg-turbo dependency in LibTIFF 4.0.9 and 4.0.10 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.10-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.10-GCCcore-8.2.0.eb
@@ -14,19 +14,21 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.10'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
 checksums = ['2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4']
 
 builddependencies = [('binutils', '2.31.1')]
+
+dependencies = [('libjpeg-turbo', '2.0.2')]
 
 configopts = " --enable-ld-version-script "
 

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.10-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.10-GCCcore-8.3.0.eb
@@ -25,6 +25,8 @@ checksums = ['2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4']
 
 builddependencies = [('binutils', '2.32')]
 
+dependencies = [('libjpeg-turbo', '2.0.3')]
+
 configopts = " --enable-ld-version-script "
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
@@ -14,13 +14,13 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.9'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
@@ -29,6 +29,10 @@ checksums = ['6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd']
 builddependencies = [
     # use same binutils version that was used when building GCCcore toolchain
     ('binutils', '2.28'),
+]
+
+dependencies = [
+    ('libjpeg-turbo', '1.5.2')
 ]
 
 configopts = " --enable-ld-version-script "

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-foss-2017b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-foss-2017b.eb
@@ -14,17 +14,21 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.9'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'foss', 'version': '2017b'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
 checksums = ['6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd']
+
+dependencies = [
+    ('libjpeg-turbo', '1.5.2')
+]
 
 configopts = " --enable-ld-version-script "
 

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2017b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2017b.eb
@@ -14,17 +14,21 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.9'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'intel', 'version': '2017b'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
 checksums = ['6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd']
+
+dependencies = [
+    ('libjpeg-turbo', '1.5.2')
+]
 
 configopts = " --enable-ld-version-script "
 

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2018.01.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2018.01.eb
@@ -14,18 +14,21 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.9'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'intel', 'version': '2018.01'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
-
 checksums = ['6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd']
+
+dependencies = [
+    ('libjpeg-turbo', '1.5.2')
+]
 
 configopts = " --enable-ld-version-script "
 

--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2018b.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-intel-2018b.eb
@@ -14,17 +14,21 @@ easyblock = 'ConfigureMake'
 name = 'LibTIFF'
 version = '4.0.9'
 
-homepage = 'http://www.remotesensing.org/libtiff/'
+homepage = 'https://www.remotesensing.org/libtiff/'
 description = "tiff: Library and tools for reading and writing TIFF data files"
 
 toolchain = {'name': 'intel', 'version': '2018b'}
 
 source_urls = [
-    'http://download.osgeo.org/libtiff/',
+    'https://download.osgeo.org/libtiff/',
     'ftp://ftp.remotesensing.org/pub/libtiff/',
 ]
 sources = ['tiff-%(version)s.tar.gz']
 checksums = ['6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd']
+
+dependencies = [
+    ('libjpeg-turbo', '2.0.0')
+]
 
 configopts = " --enable-ld-version-script "
 


### PR DESCRIPTION
@paulmelis @casparvl making the fix in https://github.com/easybuilders/easybuild-easyconfigs/pull/9146 consistent for recent `LibTIFF` easyconfigs...