### PR TITLE
stick to libjpeg-turbo 1.5.3 as dep for LibTIFF 4.0.9 w/ GCCcore/6.4.0

### DIFF
--- a/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/l/LibTIFF/LibTIFF-4.0.9-GCCcore-6.4.0.eb
@@ -32,7 +32,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('libjpeg-turbo', '1.5.2')
+    ('libjpeg-turbo', '1.5.3')
 ]
 
 configopts = " --enable-ld-version-script "


### PR DESCRIPTION
@paulmelis @casparvl We need to stick to libjpeg-turbo 1.5.3 to avoid introducing conflicts (see failing tests in https://github.com/easybuilders/easybuild-easyconfigs/pull/9146)